### PR TITLE
Fix newline character test - fixes #47

### DIFF
--- a/tests/spec.js
+++ b/tests/spec.js
@@ -8,12 +8,14 @@ const exampleResponses = [];
 var normalizedPath = require("path").join(__dirname, "exampleResponses");
 
 fs.readdirSync(normalizedPath).forEach(function (file) {
-  exampleResponses.push(require("./exampleResponses/" + file));
+  exampleResponses.push({ filename: file, json: require("./exampleResponses/" + file) });
 });
 
-const allGeneratedEmails = exampleResponses.map(({ form_response }) => {
-  return generateEmail(form_response);
+const allGeneratedResults = exampleResponses.map(({ filename: file, json: { form_response }}) => {
+  return { filename: file, email: generateEmail(form_response) };
 });
+
+const allGeneratedEmails = allGeneratedResults.map(result => result.email);
 
 describe("/api/postcode", () => {
   it("should return expected MP details for DL6 2NJ", async () => {
@@ -69,9 +71,9 @@ describe("generateEmail", () => {
       expect(res.body.search(/athiest/)).to.equal(-1);
     });
   });
-  it("should not include the 'newline' character", () => {
-    allGeneratedEmails.forEach((res) => {
-      expect(res.body.search(/\n/)).to.equal(-1);
+  it("should not include escaped 'newline' characters", () => {
+    allGeneratedResults.forEach((res) => {
+      expect(res.email.body, "In " + res.filename).not.to.contain("\\n");
     });
   });
 });


### PR DESCRIPTION
- Instead of testing no newlines are included, test that no *escaped*
  newlines are included that would show up as '\n' in the email.

- When debugging this I also improved the error messages by including
  the filename in the error message and using '.not.to.contain(..)'
  instead of 'search(..).not.to.equal(-1)' - so that it prints out the
  whole string when it fails (also test reads better).