### PR TITLE
Only write data to file in development environment

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,9 @@ const writeDataToExampleResponsesFile = (data) => {
   // Use hashed answers as filename to avoid generating multiple files containing the same responses.
   const answersJson = JSON.stringify(data.form_response.answers);
   const answersHashCode = crypto.createHash('md5').update(answersJson).digest('hex');
-  fs.writeFileSync(`./tests/exampleResponses/${answersHashCode}.json`, JSON.stringify(data));
+  const filePath = `./tests/exampleResponses/${answersHashCode}.json`;
+  fs.writeFileSync(filePath, JSON.stringify(data));
+  console.log('Wrote form data to', filePath);
 }
 
 app.get("/api/postcode/:postcodeInput", (req, res) => {
@@ -42,7 +44,9 @@ app.post("/hook", (req, res) => {
 //our webhook is triggered by the post request above
 io.on("connection", (socket) => {
   socket.on("create", (data) => {
-    writeDataToExampleResponsesFile(data);
+    if (app.settings.env === "development") {
+      writeDataToExampleResponsesFile(data);
+    }
     io.emit("typeform-incoming", {
       formToken: data.form_response.token,
       generatedEmail: generateEmail(data.form_response),


### PR DESCRIPTION
See http://expressjs.com/en/api.html#app.set for documentation of app.settings.env

In heroku, NODE_ENV should be set to production, according to this article Matthew found: https://medium.com/@_esausilva/in-heroku-process-env-node-env-e67718fb953a#:~:text=NODE_ENV%20defaults%20to%20production%20%2C%20so,IF%20statement%20will%20be%20run

Added a log when it writes to file so we can check production logs to be sure it's no longer writing files in production