### PR TITLE
Make nodemon ignore changes to tests/exampleResponses/

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "main": "server.js",
   "start": "node server.js",
   "heroku-postbuild": "cd react-app && npm install --only=dev --no-shrinkwrap && npm run build",
+  "nodemonConfig": {
+    "ignore": ["tests/exampleResponses/*"]
+  },
   "scripts": {
     "install-react": "cd react-app && npm install",
     "react-start": "cd react-app && npm start",


### PR DESCRIPTION
- Without this change, whenever a typeform response is handled by the backend in dev, it is written to tests/exampleResponses/, causing nodemon to restart unnecessarily.

- With this change, nodemon will ignore changes in this folder

- This will help with the transient proxy errors & 500s in dev, but should have no effect in production as we already don't write example response files in the prod environment (hopefully! @mattg95 can you check this?)
