### PR TITLE
Make email clickable

### DIFF
--- a/react-app/src/TextBox.jsx
+++ b/react-app/src/TextBox.jsx
@@ -29,13 +29,11 @@ const TextBox = ({ emailBody, passDataUpstream }) => {
           type="textarea"
           inputProps={{
             placeholder: "Your email will appear here",
-            rows: 15
           }}
           saveButtonContent="Apply"
           cancelButtonContent={<strong>Cancel</strong>}
           editButtonContent="Edit Your Email"
           editOnViewClick={true}
-          startEditingOnFocus
           value={emailBody} // validates the webhook response token against the response id from the embedded tyeform widget
           onSave={(val) => {
             passDataUpstream({ emailWithGreeting: val }); //if the user edits the text box, a new property called editedResponse is set in state

--- a/react-app/src/TextBox.jsx
+++ b/react-app/src/TextBox.jsx
@@ -29,10 +29,13 @@ const TextBox = ({ emailBody, passDataUpstream }) => {
           type="textarea"
           inputProps={{
             placeholder: "Your email will appear here",
+            rows: 15
           }}
           saveButtonContent="Apply"
           cancelButtonContent={<strong>Cancel</strong>}
           editButtonContent="Edit Your Email"
+          editOnViewClick={true}
+          startEditingOnFocus
           value={emailBody} // validates the webhook response token against the response id from the embedded tyeform widget
           onSave={(val) => {
             passDataUpstream({ emailWithGreeting: val }); //if the user edits the text box, a new property called editedResponse is set in state


### PR DESCRIPTION
- fixes issue #139 
- added `editOnViewClick={true}` - to make the email clickable
- added `startEditingOnFocus` - to start editing when it's tabbed 
- Decided against `submitOnUnfocus` in the end - it's a little annoying but if it improves accessibility then it's an easy add
- extra: added a `rows` property to the inputProps (which is hardcoded, so not ideal) to make the default editing area larger. It would be nice to make the rows value change depending on the generated/edited email, but there was no easy fix that I could see