### PR TITLE
stop bg image and size to prevent jump on scroll

### DIFF
--- a/react-app/src/App.scss
+++ b/react-app/src/App.scss
@@ -20,11 +20,8 @@ body {
     url("./assets/Background Small.jpg");
   background-repeat: no-repeat;
   background-attachment: fixed;
-  background-size: cover;
-  background-position: center bottom;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
+  background-size: auto 100vh;
+  background-position: center top;
 }
 
 .main {


### PR DESCRIPTION
- still has a white bar flash a the bottom of the screen when scrolling on Android, but I don't think this can be avoided
- fixes #135 